### PR TITLE
Change from storage.sync to storage.local

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -42,7 +42,7 @@ function Login() {
         }
 
         // Save the token in storage so it can be used later
-        chrome.storage.sync.set({ 
+        chrome.storage.local.set({
             'access_token' : pairsKeyValuePair['access_token'] 
         }, null);
     });

--- a/timeline.js
+++ b/timeline.js
@@ -5,7 +5,7 @@
 // Code to run when the document has loaded
 function Init() {
     // Get the access token (may be null if not logged in)
-    chrome.storage.sync.get('access_token', function(data) {
+    chrome.storage.local.get('access_token', function(data) {
         // Only run this code if an access token exists
         if (data.access_token !== null) {
             CreateOrUpdateActivity(data.access_token);


### PR DESCRIPTION
* Access tokens shouldn’t be synced ([storage.sync is unencrypted](https://developer.chrome.com/extensions/storage#using-sync))
* storage.sync isn’t available on Firefox on Android but storage.local is available in every browser
* (storage.local doesn’t complain about running in debug or as a temporary extension)