### PR TITLE
Remove GitHub from the main UI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
     "description": "Automatically sync your browsing history to your Windows 10 PC with Windows Timeline.",
     "version": "1.0.0",
     "author": "Dominic Maas",
+    "homepage_url": "https://github.com/DominicMaas/TimelineExtension#readme",
 
     "background": {
 		"scripts": ["scripts/background.js"]

--- a/menu/menu.html
+++ b/menu/menu.html
@@ -49,8 +49,8 @@
             </p>
             
             <!-- View Microsoft privacy statement -->
-            <a href="https://privacy.microsoft.com/en-us/privacystatement" target="_blank" class="inline-button">
-                <p>Microsoft Privacy Statement</p>
+            <a href="https://privacy.microsoft.com/en-us/windows-10-activity-history-and-privacy" target="_blank" class="inline-button">
+                <p>Windows 10 activity history and your privacy</p>
                 <svg viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
                     <path d="M16 14 L16 23 M16 8 L16 10" />
                     <circle cx="16" cy="16" r="14" />

--- a/menu/menu.html
+++ b/menu/menu.html
@@ -49,7 +49,7 @@
             </p>
             
             <!-- View Microsoft privacy statement -->
-            <a href="https://privacy.microsoft.com/en-us/privacystatement" class="inline-button">
+            <a href="https://privacy.microsoft.com/en-us/privacystatement" target="_blank" class="inline-button">
                 <p>Microsoft Privacy Statement</p>
                 <svg viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
                     <path d="M16 14 L16 23 M16 8 L16 10" />
@@ -73,7 +73,7 @@
             <p style="margin: 10px 15px;">Private/incognito mode browsing history is not recorded.</p>
 
             <!-- View Microsoft Account Activity History Dashboard -->
-            <a href="https://account.microsoft.com/privacy/activity-history" class="inline-button">
+            <a href="https://account.microsoft.com/privacy/activity-history" target="_blank"  class="inline-button">
                 <p>Microsoft Activity History Dashboard</p>
                 <svg id="i-activity" viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
                     <path d="M4 16 L11 16 14 29 18 3 21 16 28 16" />

--- a/menu/menu.html
+++ b/menu/menu.html
@@ -80,14 +80,6 @@
                 </svg>
             </a>          
         </section>
-
-        <!-- GitHub -->
-        <a href="https://github.com/DominicMaas/TimelineExtension" class="inline-button">
-            <p>Visit GitHub Repository</p>
-            <svg viewBox="0 0 64 64" width="32" height="32">
-                <path stroke-width="0" fill="black" d="M32 0 C14 0 0 14 0 32 0 53 19 62 22 62 24 62 24 61 24 60 L24 55 C17 57 14 53 13 50 13 50 13 49 11 47 10 46 6 44 10 44 13 44 15 48 15 48 18 52 22 51 24 50 24 48 26 46 26 46 18 45 12 42 12 31 12 27 13 24 15 22 15 22 13 18 15 13 15 13 20 13 24 17 27 15 37 15 40 17 44 13 49 13 49 13 51 20 49 22 49 22 51 24 52 27 52 31 52 42 45 45 38 46 39 47 40 49 40 52 L40 60 C40 61 40 62 42 62 45 62 64 53 64 32 64 14 50 0 32 0 Z" />
-            </svg>
-        </a>
     </section>
   </body>
 </html>


### PR DESCRIPTION
This isn’t useful and just adds an unnecessary and confusing item. You can include this in the [`homepage_url` key in the manifest](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/homepage_url).